### PR TITLE
dune-project: update ctypes lang to 0.3

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
 (lang dune 3.8)
-(using ctypes 0.1)
+(using ctypes 0.3)
 (name sentencepiece)


### PR DESCRIPTION
Dune 3.11 dropped support for ctypes long 0.1.